### PR TITLE
Sync with latest go/src/net/http/fs.go

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -264,6 +264,7 @@ func writeNotModified(w http.ResponseWriter) {
 	h := w.Header()
 	delete(h, "Content-Type")
 	delete(h, "Content-Length")
+	delete(h, "Content-Encoding")
 	if h.Get("Etag") != "" {
 		delete(h, "Last-Modified")
 	}


### PR DESCRIPTION
Include change 59ab6f351a370a27458755dc69f4a837e55a05a6.

Do NOT include change 879f595f7eacbd53d25fe21cac4b2b0cfde36449:

```
-       if modtime.Before(t) || modtime.Equal(t) {
+       if ret := modtime.Compare(t); ret <= 0 {
```

As `func (Time) Compare` was introduced in Go 1.20 and there's no reason to force a super recent version of Go.
